### PR TITLE
Catch unexpected errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::API
   include Knock::Authenticable
 
   rescue_from Exception do |e|
+    log_error_backtrace(e)
     head :internal_server_error
   end
 
@@ -31,5 +32,14 @@ class ApplicationController < ActionController::API
       end
     end
     response
+  end
+
+  private
+
+  def log_error_backtrace(e)
+    Rails.logger.error(e)
+    e.backtrace.each do |line|
+      Rails.logger.error(line)
+    end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,10 @@
 class ApplicationController < ActionController::API
   include Knock::Authenticable
 
+  rescue_from Exception do |e|
+    head :internal_server_error
+  end
+
   rescue_from ActiveRecord::RecordNotFound do |e|
     response_body = {
       errors: [

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,6 +24,15 @@ class ApplicationController < ActionController::API
     render json: response_body, status: :bad_request
   end
 
+  def not_found
+    response_body = {
+      errors: [
+        "#{request.url} does not exist"
+      ]
+    }
+    render json: response_body, status: :not_found
+  end
+
   def validation_errors(model)
     response = { errors: [] }
     model.errors.messages.each do |attribute, details|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,5 @@ Rails.application.routes.draw do
   end
   resources :snippets, only: [:index]
   get 'api-docs', to: 'apidocs#index'
+  match '*path', to: 'application#not_found', via: :all
 end

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe 'Errors', type: :request do
+  describe 'GET /users/:id.json' do
+    context 'when an internal server error occurs' do
+      before do
+        allow(User).to receive(:find).and_raise('internal server error')
+      end
+
+      it 'returns 500 Internal Server Error' do
+        get '/users/1.json'
+        expect(response.status).to eq 500
+      end
+    end
+  end
+end

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -13,4 +13,24 @@ RSpec.describe 'Errors', type: :request do
       end
     end
   end
+
+  describe 'GET *path.json' do
+    context 'when specified URL does not exist' do
+      it 'returns error messages' do
+        get '/not_exist.json'
+
+        expect(response.status).to eq 404
+
+        expected_json = {
+          errors: [
+            String
+          ]
+        }
+        expect(response.body).to be_json_as expected_json
+
+        json = JSON.parse(response.body)
+        expect(json['errors'].first).to match /does not exist\Z/
+      end
+    end
+  end
 end


### PR DESCRIPTION
- 500
  - when internal errors occur
- 404
  - when API receives requests for endpoints which do not exist